### PR TITLE
TransactionAwareDataSourceProxyを使用する箇所をSpring管理外のみに変更。

### DIFF
--- a/src/main/java/sample/ApplicationConfiguration.java
+++ b/src/main/java/sample/ApplicationConfiguration.java
@@ -23,7 +23,7 @@ public class ApplicationConfiguration {
         DataSource dataSource = new EmbeddedDatabaseBuilder()
                 .setType(EmbeddedDatabaseType.H2).addScript("import.sql")
                 .build();
-        return new TransactionAwareDataSourceProxy(dataSource);
+        return dataSource;
     }
 
     @Bean
@@ -47,7 +47,7 @@ public class ApplicationConfiguration {
 
             @Override
             public DataSource getDataSource() {
-                return dataSource();
+                return new TransactionAwareDataSourceProxy(dataSource());
             }
         };
     }


### PR DESCRIPTION
`TransactionAwareDataSourceProxy`を使用する箇所をSpring管理外のみに変更しました。

`TransactionAwareDataSourceProxy`でくるんだ`DataSource`をSpring側で管理しなくてよいのでは？
